### PR TITLE
Added a maven-projects example for accessing image metadata

### DIFF
--- a/maven-projects/metadata/pom.xml
+++ b/maven-projects/metadata/pom.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+		http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.scijava</groupId>
+		<artifactId>pom-scijava</artifactId>
+		<version>16.1.0</version>
+		<relativePath />
+	</parent>
+
+	<groupId>imagej-tutorials</groupId>
+	<artifactId>metadata</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+
+	<name>Metadata</name>
+	<description>This example shows how to access and print metadata with SCIFIO.</description>
+	<url>https://github.com/[MY-ORG]/[MY-REPO]</url>
+	<inceptionYear>2013</inceptionYear>
+	<organization>
+		<name>[MY-ORGANIZATION-NAME]</name>
+		<url>[MY-ORGANIZATION-WEB-SITE]</url>
+	</organization>
+	<licenses>
+		<license>
+			<name>CC0 1.0 Universal License</name>
+			<url>http://creativecommons.org/publicdomain/zero/1.0/</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
+
+	<developers>
+		<developer>
+			<id>[MY-GITHUB-ID]</id>
+			<name>[MY-FULL-NAME]</name>
+			<url>https://imagej.net/User:[MY-IMAGEJ-WIKI-ACCOUNT]</url>
+		</developer>
+	</developers>
+	<contributors>
+		<contributor>
+			<name>None</name>
+		</contributor>
+	</contributors>
+
+	<mailingLists>
+		<mailingList>
+			<name>ImageJ Forum</name>
+			<archive>http://forum.imagej.net/</archive>
+		</mailingList>
+	</mailingLists>
+
+	<scm>
+		<connection>scm:git:git://github.com/[MY-ORG]/[MY-REPO]</connection>
+		<developerConnection>scm:git:git@github.com:[MY-ORG]/[MY-REPO]</developerConnection>
+		<tag>HEAD</tag>
+		<url>https://github.com/[MY-ORG]/[MY-REPO]</url>
+	</scm>
+	<issueManagement>
+		<system>GitHub Issues</system>
+		<url>http://github.com/[MY-ORG]/[MY-REPO]/issues</url>
+	</issueManagement>
+	<ciManagement>
+		<system>None</system>
+	</ciManagement>
+
+	<properties>
+		<main-class>PrintMetadata</main-class>
+		<license.licenseName>cc0</license.licenseName>
+		<license.copyrightOwners>N/A</license.copyrightOwners>
+		<license.projectName>ImageJ software for multidimensional image processing and analysis.</license.projectName>
+	</properties>
+
+	<repositories>
+		<repository>
+			<id>imagej.public</id>
+			<url>http://maven.imagej.net/content/groups/public</url>
+		</repository>
+	</repositories>
+
+	<dependencies>
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>imagej</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.scif</groupId>
+			<artifactId>scifio</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.scif</groupId>
+			<artifactId>scifio-bf-compat</artifactId>
+            <scope>runtime</scope>
+		</dependency>
+        <dependency>
+            <groupId>ome</groupId>
+            <artifactId>formats-bsd</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>ome</groupId>
+            <artifactId>formats-gpl</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+	</dependencies>
+</project>

--- a/maven-projects/metadata/pom.xml
+++ b/maven-projects/metadata/pom.xml
@@ -8,18 +8,18 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>16.1.0</version>
+		<version>17.1.1</version>
 		<relativePath />
 	</parent>
 
 	<groupId>imagej-tutorials</groupId>
 	<artifactId>metadata</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>0.1.0-SNAPSHOT</version>
 
 	<name>Metadata</name>
-	<description>This example shows how to access and print metadata with SCIFIO.</description>
+	<description>This example shows how to access and display metadata with SCIFIO.</description>
 	<url>https://github.com/[MY-ORG]/[MY-REPO]</url>
-	<inceptionYear>2013</inceptionYear>
+	<inceptionYear>2017</inceptionYear>
 	<organization>
 		<name>[MY-ORGANIZATION-NAME]</name>
 		<url>[MY-ORGANIZATION-WEB-SITE]</url>
@@ -67,7 +67,7 @@
 	</ciManagement>
 
 	<properties>
-		<main-class>PrintMetadata</main-class>
+		<main-class>GetMetadata</main-class>
 		<license.licenseName>cc0</license.licenseName>
 		<license.copyrightOwners>N/A</license.copyrightOwners>
 		<license.projectName>ImageJ software for multidimensional image processing and analysis.</license.projectName>
@@ -92,17 +92,17 @@
 		<dependency>
 			<groupId>io.scif</groupId>
 			<artifactId>scifio-bf-compat</artifactId>
-            <scope>runtime</scope>
+			<scope>runtime</scope>
 		</dependency>
-        <dependency>
-            <groupId>ome</groupId>
-            <artifactId>formats-bsd</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>ome</groupId>
-            <artifactId>formats-gpl</artifactId>
-            <scope>runtime</scope>
-        </dependency>
+		<dependency>
+			<groupId>ome</groupId>
+			<artifactId>formats-bsd</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>ome</groupId>
+			<artifactId>formats-gpl</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/maven-projects/metadata/src/main/java/GetMetadata.java
+++ b/maven-projects/metadata/src/main/java/GetMetadata.java
@@ -24,17 +24,18 @@ import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
- * This example illustrates how to print image metadata using the {@link FormatService} and {@link FieldPrinter}.
+ * This example illustrates how to access and display image metadata using the {@link FormatService} and
+ * {@link FieldPrinter}.
  * <p>
  * We use the {@link FormatService} to determine the {@link Format} of the input image. Then, we parse
- * the metadata from the image file and use {@link FieldPrinter} to print the metadata fields as strings.
+ * the metadata from the image file and use {@link FieldPrinter} to retrieve the metadata fields as strings.
  * </p>
  * <p>
  * An optional {@code formatMetadata} method is included to (hopefully) make the text more readable.
  * </p>
  */
-@Plugin(type = Command.class, menuPath = "Plugins>Print Metadata")
-public class PrintMetadata implements Command {
+@Plugin(type = Command.class, menuPath = "Image>Show Metadata")
+public class GetMetadata implements Command {
 
     // -- Needed services --
 
@@ -116,7 +117,7 @@ public class PrintMetadata implements Command {
         ij.ui().show(img);
 
         // invoke the plugin
-        ij.command().run(PrintMetadata.class, true);
+        ij.command().run(GetMetadata.class, true);
 
     }
 

--- a/maven-projects/metadata/src/main/java/PrintMetadata.java
+++ b/maven-projects/metadata/src/main/java/PrintMetadata.java
@@ -1,0 +1,123 @@
+/*
+ * To the extent possible under law, the ImageJ developers have waived
+ * all copyright and related or neighboring rights to this tutorial code.
+ *
+ * See the CC0 1.0 Universal license for details:
+ *     http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+import java.io.IOException;
+
+import io.scif.services.FormatService;
+import io.scif.Format;
+import io.scif.FormatException;
+import io.scif.Metadata;
+import io.scif.FieldPrinter;
+
+import net.imagej.ImageJ;
+import net.imagej.Dataset;
+
+import org.scijava.ItemIO;
+import org.scijava.command.Command;
+import org.scijava.log.LogService;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * This example illustrates how to print image metadata using the {@link FormatService} and {@link FieldPrinter}.
+ * <p>
+ * We use the {@link FormatService} to determine the {@link Format} of the input image. Then, we parse
+ * the metadata from the image file and use {@link FieldPrinter} to print the metadata fields as strings.
+ * </p>
+ * <p>
+ * An optional {@code formatMetadata} method is included to (hopefully) make the text more readable.
+ * </p>
+ */
+@Plugin(type = Command.class, menuPath = "Plugins>Print Metadata")
+public class PrintMetadata implements Command {
+
+    // -- Needed services --
+
+    // for determining the Format of the input image
+    @Parameter
+    private FormatService formatService;
+
+    // for logging errors
+    @Parameter
+    private LogService log;
+
+    // -- Inputs and outputs to the command --
+
+    // input image
+    @Parameter
+    private Dataset img;
+
+    // output metadata string
+    @Parameter(label = "Metadata", type = ItemIO.OUTPUT)
+    private String mString;
+
+    @Override
+    public void run() {
+        // we need the file path to determine the file format
+        final String filePath = img.getSource();
+
+        // catch any Format or IO exceptions
+        try {
+
+            // determine the Format based on the extension and, if necessary, the source data
+            Format format = formatService.getFormat(filePath);
+
+            // create an instance of the associated Parser and parse metadata from the image file
+            Metadata metadata = format.createParser().parse(filePath);
+
+            // use FieldPrinter to traverse metadata tree and return as a String
+            String metadataTree = new FieldPrinter(metadata).toString();
+
+            // (optional) remove some of the tree formatting to make the metadata easier to read
+            mString = formatMetadata(metadataTree);
+        }
+        catch (final FormatException | IOException e) {
+            log.error(e);
+        }
+
+    }
+
+    /**
+     * This function makes the metadata easier to read by removing some of the tree formatting from FieldPrinter.
+     * @param metadataTree raw metadata string returned by FieldPrinter().toString()
+     * @return formatted version of metadataTree
+     */
+    private String formatMetadata(String metadataTree) {
+
+        // remove ending braces | replace ", " between OME fields
+        String tmp = metadataTree.replaceAll("(\\t+}\\n)|(,\\s)", "\n");
+
+        // remove beginning braces | remove indenting
+        return tmp.replaceAll("(\\t+\\{\\n)|(\\t+)", "");
+    }
+
+    /**
+     * This main function serves for development purposes.
+     * It allows you to run the plugin immediately out of
+     * your integrated development environment (IDE).
+     *
+     * @param args unused
+     * @throws Exception
+     */
+    public static void main(final String... args) throws Exception {
+        // create the ImageJ application context with all available services
+        final ImageJ ij = new ImageJ();
+        ij.launch(args);
+
+        // open a sample image
+        final Dataset img = ij.scifio().datasetIO().open("http://imagej.net/images/FluorescentCells.jpg");
+
+        // show the image
+        ij.ui().show(img);
+
+        // invoke the plugin
+        ij.command().run(PrintMetadata.class, true);
+
+    }
+
+}


### PR DESCRIPTION
I've added a `maven-projects` example for printing image metadata (based on issue #35). I understand that this example is not in line with the effort to unify the tutorials as notebooks (issue #30), but I think this example is still of value to aspiring plugin programmers. 