### PR TITLE
Escaped "top" in the last cell

### DIFF
--- a/notebooks/1-Using-ImageJ/2-ImageJ-Ops.ipynb
+++ b/notebooks/1-Using-ImageJ/2-ImageJ-Ops.ipynb
@@ -2736,7 +2736,7 @@
     "s += \"</style>\"\n",
     "s += \"<table class=\\\"op-index\\\" border=0 cellpadding=0><tbody><tr>\"\n",
     "for (col in cols) {\n",
-    "    s += \"<td valign=\"top\">\"\n",
+    "    s += \"<td valign=\\\"top\\\">\"\n",
     "    for (ns in col) {\n",
     "        // Nested tables! Great plan? Or the greatest plan?\n",
     "        s += \"<table class=\\\"op-namespace\\\"><tbody>\"\n",


### PR DESCRIPTION
When I tried to run through the notebook, I got an error in the last cell, but as it looked like a missing escape, I just added an escape around the quotes and it worked. I edited the ipynb from vi to avoid irrelevant changes in the ipynb (i.e. every single cell's output updated). Sidenote: the awesome linking feature stops working in my fork (something to do with 'tp81' vs 'imagej' I guess), not a big deal: I just did the fork to do a PR... I'll switch back to the imagej/tutorials to run it.