### PR TITLE
Move beakerx installation to postBuild

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,7 +2,6 @@ name: scijava
 channels:
   - conda-forge
 dependencies:
-  - beakerx=1.3.0
   - jupyter_contrib_nbextensions
   - numpy
   - openjdk=8

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,1 @@
+conda install beakerx


### PR DESCRIPTION
This works around an issue with conda when installing `beakerx` via `environment.yml`.
See https://github.com/imagej/tutorials/issues/62#issuecomment-482739647.