### PR TITLE
Add custom widget style demo

### DIFF
--- a/maven-projects/widget-demo/pom.xml
+++ b/maven-projects/widget-demo/pom.xml
@@ -85,5 +85,10 @@
 			<groupId>net.imagej</groupId>
 			<artifactId>imagej</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.scijava</groupId>
+			<artifactId>scijava-ui-swing</artifactId>
+			<version>0.12.0</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/maven-projects/widget-demo/src/main/java/CustomWidget.java
+++ b/maven-projects/widget-demo/src/main/java/CustomWidget.java
@@ -1,0 +1,84 @@
+import org.scijava.Priority;
+import org.scijava.plugin.Plugin;
+import org.scijava.ui.swing.widget.SwingInputWidget;
+import org.scijava.widget.ChoiceWidget;
+import org.scijava.widget.InputWidget;
+import org.scijava.widget.WidgetModel;
+
+import javax.swing.*;
+import java.awt.*;
+
+@Plugin(type = InputWidget.class, priority = Priority.HIGH)
+public class CustomWidget extends SwingInputWidget<String> implements ChoiceWidget<JPanel> {
+
+    public static final String CUSTOM_STYLE = "custom";
+
+    private final JButton addButton = new JButton("Add");
+
+    private DefaultListModel<String> choices;
+    private JList<String> listComponent;
+
+
+    // -- InputWidget methods --
+
+    @Override
+    public String getValue() {
+        return listComponent.getSelectedValue();
+    }
+
+    // -- WrapperPlugin methods --
+
+    @Override
+    public void set(final WidgetModel model) {
+        super.set(model);
+
+        addButton.addActionListener(actionEvent -> addChoice());
+
+        JPanel component = getComponent();
+
+        choices = new DefaultListModel<>();
+        final String[] items = model.getChoices();
+        for (final String item : items) {
+            choices.addElement(item);
+        }
+
+        listComponent = new JList<>(choices);
+        listComponent.addListSelectionListener(e -> {
+            if (!e.getValueIsAdjusting()) {
+                updateModel();
+            }
+        });
+
+        JPanel container = new JPanel();
+
+        container.setLayout(new GridLayout(2, 1));
+        container.add(addButton);
+        container.add(listComponent);
+
+        component.add(container);
+
+        refreshWidget();
+    }
+
+    // -- Typed methods --
+
+    @Override
+    public boolean supports(final WidgetModel model) {
+        return super.supports(model) && model.isMultipleChoice() && model.isStyle(CUSTOM_STYLE);
+    }
+
+    // -- Helper methods --
+
+    private void addChoice() {
+        JFrame frame = new JFrame("Input");
+        String choice = JOptionPane.showInputDialog(frame, "Enter animal");
+        if (choice != null) {
+            choices.addElement(choice);
+        }
+    }
+
+    // -- AbstractUIInputWidget methods ---
+
+    @Override
+    public void doRefresh() { /* No-op. */ }
+}

--- a/maven-projects/widget-demo/src/main/java/WidgetDemo.java
+++ b/maven-projects/widget-demo/src/main/java/WidgetDemo.java
@@ -208,6 +208,10 @@ public class WidgetDemo implements Command, Previewable {
 			"Really liked", "Liked", "Disliked", "Really disliked" })
 	private String choiceRadioV;
 
+	@Parameter(label = "custom widget",
+			style = CustomWidget.CUSTOM_STYLE, choices = {"Badger"})
+	private String customString;
+
 	// This section demonstrates how to use callbacks. A "callback" is a
 	// method that is executed whenever a specific parameter value changes.
 	// They can be used for many purposes; in our case, we use them to keep


### PR DESCRIPTION
This PR adds a custom widget to the `WidgetDemo` project. I have been working on an ImageJ plugin recently where we require a lot of flexibility, and it would have been extremely helpful to have this kind of functionality documented. ImageJ is built to be extensible (almost to a fault), but the lack of documentation means a lot of this potential goes wasted.

![image](https://user-images.githubusercontent.com/20669173/83953679-114c3d00-a83a-11ea-9a9c-6afba505d1c4.png)
