### PR TITLE
Tutorials and Demo: Fix usage of createMinSize

### DIFF
--- a/notebooks/ImageJ-Tutorials-and-Demo.ipynb
+++ b/notebooks/ImageJ-Tutorials-and-Demo.ipynb
@@ -275,9 +275,9 @@
    ],
    "source": [
     "import net.imglib2.FinalInterval\n",
-    "min = [85, 0, 110]\n",
-    "len = [5, 335, 1]\n",
-    "bounds = FinalInterval.createMinSize(min[0], len[0], min[1], len[1], min[2], len[2])\n",
+    "min = [85, 5, 0]\n",
+    "len = [335, 110, 1]\n",
+    "bounds = FinalInterval.createMinSize(min[0], min[1], min[2], len[0], len[1], len[2])\n",
     "eyes = ij.op().transform().crop(mandrill, bounds, true)"
    ]
   },


### PR DESCRIPTION
The order of arguments for `FinalInterval.createMinSize` was wrong. This mistake was compensated by a wrong initialization of the arrays `min` and `len`, hence overall leading to the expected result.

This PR just fixes the minor above mistake.